### PR TITLE
Changed window location href

### DIFF
--- a/app/javascript/plugins/init_placesave.js
+++ b/app/javascript/plugins/init_placesave.js
@@ -24,7 +24,7 @@ const placeSelection = () => {
             char.push(`location${counter}=${place}`)
             counter += 1
         })
-        window.location.href = `http://localhost:3000/activities?${char.join('&')}`
+        window.location.href = `${window.location.origin}/activities?${char.join('&')}`
       }
 };
 


### PR DESCRIPTION
Changed window location href value in the initPlacesave function; original function was redirecting to localhost even if clicked on Heroku; new function redirects to localhost if working on localhost, and to heroku if using the heroku app (and to custom domain if using custom domain)